### PR TITLE
Setup a default tracer and use it in the HttpTextFormat test

### DIFF
--- a/api/include/opentelemetry/trace/default_span.h
+++ b/api/include/opentelemetry/trace/default_span.h
@@ -4,7 +4,7 @@
 #include "opentelemetry/trace/canonical_code.h"
 #include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/trace/span.h"
-//#include "opentelemetry/trace/tracer.h"
+#include "opentelemetry/trace/tracer.h"
 
 #define pass
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -12,9 +12,9 @@ namespace trace {
 class DefaultSpan: public Span {
   public:
     // Returns an invalid span.
-    static DefaultSpan GetInvalid() {
-        return DefaultSpan(SpanContext::GetInvalid());
-    }
+    // static DefaultSpan GetInvalid() {
+    //     return DefaultSpan(SpanContext::GetInvalid());
+    // }
 
     trace::SpanContext GetContext() const noexcept {
         return span_context_;
@@ -57,11 +57,11 @@ class DefaultSpan: public Span {
       return "DefaultSpan";
     }
 
-    DefaultSpan() = default;
+    DefaultSpan(Tracer *tracer) : tracer_(tracer) {}
 
-    DefaultSpan(SpanContext span_context) {
-       this->span_context_ = span_context;
-    }
+    DefaultSpan(Tracer *tracer, SpanContext span_context)
+        : span_context_(span_context), tracer_(tracer)
+    {}
 
     // movable and copiable
     DefaultSpan(DefaultSpan&& spn) : span_context_(spn.GetContext()) {}
@@ -69,18 +69,17 @@ class DefaultSpan: public Span {
 
     // This is an invalid implementation
     trace::Tracer &tracer() const noexcept {
-      trace::Tracer tracer = trace::Tracer();
-      return tracer; // Invalid tracer
+      return *tracer_;
     }
 
     // Creates an instance of this class with spancontext.
-    static DefaultSpan Create(SpanContext span_context) {
-      return DefaultSpan(span_context);
-    }
+    // static DefaultSpan Create(SpanContext span_context) {
+    //   return DefaultSpan(span_context);
+    // }
 
   private:
     SpanContext span_context_;
-    trace::Tracer tracer_;
+    Tracer *tracer_;
 };
 }
 OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/trace/default_tracer.h
+++ b/api/include/opentelemetry/trace/default_tracer.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/trace/tracer.h"
+#include "opentelemetry/version.h"
+
+#include <chrono>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+/**
+ * Handles span creation and in-process context propagation.
+ *
+ * This class provides methods for manipulating the context, creating spans, and controlling spans'
+ * lifecycles.
+ */
+class DefaultTracer : public Tracer
+{
+public:
+  virtual ~DefaultTracer() = default;
+  /**
+   * Starts a span.
+   *
+   * Optionally sets attributes at Span creation from the given key/value pairs.
+   *
+   * Attributes will be processed in order, previous attributes with the same
+   * key will be overwritten.
+   */
+  virtual nostd::unique_ptr<Span> StartSpan(nostd::string_view name,
+                                            const KeyValueIterable &attributes,
+                                            const StartSpanOptions &options = {}) noexcept {
+    return nostd::unique_ptr<Span>(new DefaultSpan(this));
+  }
+
+  virtual void ForceFlushWithMicroseconds(uint64_t timeout) noexcept {}
+
+  virtual void CloseWithMicroseconds(uint64_t timeout) noexcept {};
+};
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -9,7 +9,6 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/trace/canonical_code.h"
 #include "opentelemetry/trace/key_value_iterable_view.h"
-#include "opentelemetry/trace/tracer.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -7,9 +7,6 @@
 
 #include <chrono>
 
-class Span;
-struct StartSpanOptions;
-
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace trace
 {

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -1,14 +1,14 @@
 #include "opentelemetry/trace/propagation/http_text_format.h"
-#include "opentelemetry/trace/propagation/http_trace_context.h"
 #include "opentelemetry/context/context.h"
-#include "opentelemetry/trace/span.h"
-#include "opentelemetry/trace/default_span.h"
-#include "opentelemetry/trace/span_context.h"
-#include "opentelemetry/nostd/string_view.h"
-#include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/trace/default_tracer.h"
+#include "opentelemetry/trace/propagation/http_trace_context.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/trace_id.h"
-
 
 #include <map>
 #include <memory>
@@ -55,14 +55,18 @@ TEST(HTTPTextFormatTest, TraceFlagsBufferGeneration)
 
 TEST(HTTPTextFormatTest, HeadersWithTraceState)
 {
-    const std::map<std::string,std::string> carrier = {{"traceparent","00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"},{"tracestate","congo=congosSecondPosition,rojo=rojosFirstPosition"}};
-    context::Context ctx1 = context::Context("current-span",nostd::shared_ptr<trace::Span>(new trace::DefaultSpan()));
-    context::Context ctx2 = format.Extract(Getter,carrier,ctx1);
-    std::map<std::string,std::string> c2 = {};
-    format.Inject(Setter,c2,ctx2);
-    EXPECT_EQ(c2["traceparent"],"00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01");
-    EXPECT_EQ(c2["tracestate"],"congo=congosSecondPosition,rojo=rojosFirstPosition");
-    EXPECT_EQ(carrier.size(),c2.size());
+  const std::map<std::string, std::string> carrier = {
+      {"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"},
+      {"tracestate", "congo=congosSecondPosition,rojo=rojosFirstPosition"}};
+  std::unique_ptr<trace::Tracer> tracer(new trace::DefaultTracer());
+  context::Context ctx1 = context::Context(
+      "current-span", nostd::shared_ptr<trace::Span>(tracer->StartSpan("test span").release()));
+  context::Context ctx2 = format.Extract(Getter, carrier, ctx1);
+  std::map<std::string, std::string> c2 = {};
+  format.Inject(Setter, c2, ctx2);
+  EXPECT_EQ(c2["traceparent"], "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01");
+  EXPECT_EQ(c2["tracestate"], "congo=congosSecondPosition,rojo=rojosFirstPosition");
+  EXPECT_EQ(carrier.size(), c2.size());
 }
 
 TEST(HTTPTextFormatTest, NoTraceParentHeader)
@@ -70,7 +74,9 @@ TEST(HTTPTextFormatTest, NoTraceParentHeader)
     // When trace context headers are not present, a new SpanContext
     // should be created.
     const std::map<std::string,std::string> carrier = {};
-    context::Context ctx1 = context::Context("current-span",nostd::shared_ptr<trace::Span>(new trace::DefaultSpan()));
+    std::unique_ptr<trace::Tracer> tracer(new trace::DefaultTracer());
+    context::Context ctx1 = context::Context(
+      "current-span", nostd::shared_ptr<trace::Span>(tracer->StartSpan("test span").release()));
     context::Context ctx2 = format.Extract(Getter, carrier, ctx1);
     trace::Span* span = MapHttpTraceContext::GetCurrentSpan(ctx2);
     EXPECT_EQ(span->GetContext().trace_id(),trace::SpanContext().trace_id());
@@ -86,7 +92,9 @@ TEST(HTTPTextFormatTest, InvalidTraceId)
     // Also ignore any trace state.
     const std::map<std::string,std::string> carrier = { {"traceparent", "00-00000000000000000000000000000000-1234567890123456-00"},
                                                                {"tracestate", "foo=1,bar=2,foo=3"} };
-    context::Context ctx1 = context::Context("current-span",nostd::shared_ptr<trace::Span>(new trace::DefaultSpan()));
+    std::unique_ptr<trace::Tracer> tracer(new trace::DefaultTracer());
+    context::Context ctx1 = context::Context(
+      "current-span", nostd::shared_ptr<trace::Span>(tracer->StartSpan("test span").release()));
     context::Context ctx2 = format.Extract(Getter, carrier, ctx1);
     trace::Span* span = MapHttpTraceContext::GetCurrentSpan(ctx2);
     EXPECT_EQ(span->GetContext().trace_id(),trace::SpanContext().trace_id());
@@ -102,7 +110,9 @@ TEST(HTTPTextFormatTest, InvalidParentId)
     // Also ignore any trace state.
     const std::map<std::string,std::string> carrier = { {"traceparent", "00-00000000000000000000000000000000-0000000000000000-00"},
                                                                {"tracestate", "foo=1,bar=2,foo=3"} };
-    context::Context ctx1 = context::Context("current-span",nostd::shared_ptr<trace::Span>(new trace::DefaultSpan()));
+    std::unique_ptr<trace::Tracer> tracer(new trace::DefaultTracer());
+    context::Context ctx1 = context::Context(
+      "current-span", nostd::shared_ptr<trace::Span>(tracer->StartSpan("test span").release()));
     context::Context ctx2 = format.Extract(Getter, carrier, ctx1);
     trace::Span* span = MapHttpTraceContext::GetCurrentSpan(ctx2);
     EXPECT_EQ(span->GetContext().trace_id(),trace::SpanContext().trace_id());
@@ -115,7 +125,9 @@ TEST(HTTPTextFormatTest, NoSendEmptyTraceState)
 {
     // If the trace state is empty, do not set the header.
     const std::map<std::string,std::string> carrier = {{"traceparent","00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"}};
-    context::Context ctx1 = context::Context("current-span",nostd::shared_ptr<trace::Span>(new trace::DefaultSpan()));
+    std::unique_ptr<trace::Tracer> tracer(new trace::DefaultTracer());
+    context::Context ctx1 = context::Context(
+      "current-span", nostd::shared_ptr<trace::Span>(tracer->StartSpan("test span").release()));
     context::Context ctx2 = format.Extract(Getter,carrier,ctx1);
     std::map<std::string,std::string> c2 = {};
     format.Inject(Setter,c2,ctx2);
@@ -129,7 +141,9 @@ TEST(HTTPTextFormatTest, FormatNotSupported)
     // create a new trace context.
     const std::map<std::string,std::string> carrier = { {"traceparent", "00-12345678901234567890123456789012-1234567890123456-00-residue"},
                                                                {"tracestate", "foo=1,bar=2,foo=3"} };
-    context::Context ctx1 = context::Context("current-span",nostd::shared_ptr<trace::Span>(new trace::DefaultSpan()));
+    std::unique_ptr<trace::Tracer> tracer(new trace::DefaultTracer());
+    context::Context ctx1 = context::Context(
+      "current-span", nostd::shared_ptr<trace::Span>(tracer->StartSpan("test span").release()));
     context::Context ctx2 = format.Extract(Getter,carrier,ctx1);
     trace::Span* span = MapHttpTraceContext::GetCurrentSpan(ctx2);
     EXPECT_FALSE(span->GetContext().IsValid());
@@ -139,21 +153,14 @@ TEST(HTTPTextFormatTest, FormatNotSupported)
     EXPECT_EQ(span->GetContext().trace_state(),trace::SpanContext().trace_state());
 }
 
-TEST(HTTPTextFormatTest, PropagateInvalidContext)
-{
-    // Do not propagate invalid trace context.
-    std::map<std::string,std::string> carrier = {};
-    context::Context ctx{"current-span",nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(trace::SpanContext::GetInvalid()))};
-    format.Inject(Setter, carrier, ctx);
-    EXPECT_TRUE(carrier.count("traceparent") == 0);
-}
-
 TEST(HTTPTextFormatTest, TraceStateHeaderWithTrailingComma)
 {
     // Do not propagate invalid trace context.
     const std::map<std::string,std::string> carrier = { {"traceparent", "00-12345678901234567890123456789012-1234567890123456-00"},
                                                                {"tracestate", "foo=1,"} };
-    context::Context ctx1 = context::Context("current-span",nostd::shared_ptr<trace::Span>(new trace::DefaultSpan()));
+    std::unique_ptr<trace::Tracer> tracer(new trace::DefaultTracer());
+    context::Context ctx1 = context::Context(
+      "current-span", nostd::shared_ptr<trace::Span>(tracer->StartSpan("test span").release()));
     context::Context ctx2 = format.Extract(Getter,carrier,ctx1);
     trace::Span* span = MapHttpTraceContext::GetCurrentSpan(ctx2);
     trace::TraceState trace_state = span->GetContext().trace_state();
@@ -166,7 +173,9 @@ TEST(HTTPTextFormatTest, TraceStateKeys)
     std::string trace_state_value = "1a-2f@foo=bar1,1a-_*/2b@foo=bar2,foo=bar3,foo-_*/bar=bar4";
     const std::map<std::string,std::string> carrier = { {"traceparent", "00-12345678901234567890123456789012-1234567890123456-00"},
                                                                {"tracestate", trace_state_value} };
-    context::Context ctx1 = context::Context("current-span",nostd::shared_ptr<trace::Span>(new trace::DefaultSpan()));
+    std::unique_ptr<trace::Tracer> tracer(new trace::DefaultTracer());
+    context::Context ctx1 = context::Context(
+      "current-span", nostd::shared_ptr<trace::Span>(tracer->StartSpan("test span").release()));
     context::Context ctx2 = format.Extract(Getter,carrier,ctx1);
     trace::Span* span = MapHttpTraceContext::GetCurrentSpan(ctx2);
     trace::TraceState trace_state = span->GetContext().trace_state();


### PR DESCRIPTION
Resolves the dependency issues between tracer and span.

Note the test using invalid span is removed.